### PR TITLE
Add order status notification signal

### DIFF
--- a/backend/apps/notification/apps.py
+++ b/backend/apps/notification/apps.py
@@ -1,6 +1,10 @@
 from django.apps import AppConfig  
   
   
-class NotificationConfig(AppConfig):  
-    default_auto_field = 'django.db.models.BigAutoField'  
-    name = 'apps.notification' 
+class NotificationConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.notification'
+
+    def ready(self):
+        """Connect signal handlers for the notification app."""
+        from . import signals  # noqa

--- a/backend/apps/notification/signals.py
+++ b/backend/apps/notification/signals.py
@@ -1,0 +1,29 @@
+from django.db.models.signals import pre_save, post_save
+from django.dispatch import receiver
+from apps.orders.models import Order
+from .models import Notification
+
+@receiver(pre_save, sender=Order)
+def store_previous_status(sender, instance, **kwargs):
+    """Store the current status before saving to detect changes."""
+    if instance.pk:
+        try:
+            instance._previous_status = Order.objects.get(pk=instance.pk).status
+        except Order.DoesNotExist:
+            instance._previous_status = None
+
+@receiver(post_save, sender=Order)
+def order_status_notification(sender, instance, created, **kwargs):
+    """Create a notification when an order status changes."""
+    if created:
+        return
+
+    previous_status = getattr(instance, "_previous_status", None)
+    if previous_status and previous_status != instance.status:
+        Notification.objects.create(
+            user=instance.customer,
+            business=instance.business,
+            type="order_status",
+            title="به‌روزرسانی وضعیت سفارش",
+            content=f"وضعیت سفارش شما به {instance.get_status_display()} تغییر یافت.",
+        )

--- a/backend/apps/notification/tests.py
+++ b/backend/apps/notification/tests.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 from django.contrib.auth import get_user_model
 from apps.business.models import Business
+from apps.orders.models import Order
 from .models import Notification, NotificationCategory
 import uuid
 
@@ -22,7 +23,6 @@ class NotificationModelTests(TestCase):
         )
         self.business = Business.objects.create(
             name='کسب‌وکار تست',
-            status='active',
             owner=self.user
         )
         self.category = NotificationCategory.objects.create(
@@ -75,7 +75,6 @@ class NotificationAPITests(TestCase):
         )
         self.business = Business.objects.create(
             name='کسب‌وکار تست',
-            status='active',
             owner=self.user
         )
         self.category = NotificationCategory.objects.create(
@@ -201,3 +200,35 @@ class NotificationAPITests(TestCase):
         # بررسی اعمال تغییرات
         notification.refresh_from_db()
         self.assertTrue(notification.is_archived)
+
+class OrderNotificationSignalTests(TestCase):
+    """Tests for order status change notifications."""
+
+    def setUp(self):
+        self.customer = User.objects.create_user(
+            username='customer',
+            email='customer@example.com',
+            password='password123'
+        )
+        self.owner = User.objects.create_user(
+            username='owner',
+            email='owner@example.com',
+            password='ownerpass'
+        )
+        self.business = Business.objects.create(
+            name='کسب‌وکار تست',
+            owner=self.owner
+        )
+
+    def test_status_change_creates_notification(self):
+        order = Order.objects.create(
+            customer=self.customer,
+            business=self.business,
+            status='pending'
+        )
+        order.status = 'confirmed'
+        order.save()
+
+        self.assertTrue(
+            Notification.objects.filter(user=self.customer, type='order_status').exists()
+        )

--- a/backend/apps/orders/signals.py
+++ b/backend/apps/orders/signals.py
@@ -155,22 +155,19 @@ def send_order_notifications(sender, instance, created, **kwargs):
             # اطلاعیه ایجاد سفارش به مشتری
             Notification.objects.create(
                 user=instance.customer,
+                type='order',
                 title="ثبت سفارش جدید",
-                message=f"سفارش شما با شماره {str(instance.id)[:8]} ثبت شد.",
-                notification_type='order_created',
-                data={'order_id': str(instance.id)}
+                content=f"سفارش شما با شماره {str(instance.id)[:8]} ثبت شد."
             )
             
-            # اطلاعیه به کسب‌وکار (در صورت وجود)
+            # اطلاعیه به مالک کسب‌وکار (در صورت وجود)
             if instance.business:
-                for business_user in instance.business.users.filter(roles__name='business_manager'):
-                    Notification.objects.create(
-                        user=business_user.user,
-                        title="سفارش جدید",
-                        message=f"سفارش جدید با شماره {str(instance.id)[:8]} دریافت شد.",
-                        notification_type='new_order_received',
-                        data={'order_id': str(instance.id)}
-                    )
+                Notification.objects.create(
+                    user=instance.business.owner,
+                    type='order',
+                    title="سفارش جدید",
+                    content=f"سفارش جدید با شماره {str(instance.id)[:8]} دریافت شد."
+                )
     
     except ImportError:
         # مدل Notification وجود ندارد


### PR DESCRIPTION
## Summary
- connect new signal handlers in notification app
- notify customer when order status changes
- adjust order signals for new notification model
- add regression test for status change notification

## Testing
- `python backend/manage.py test apps.notification.tests.OrderNotificationSignalTests -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68496074f974832a9333f8eb9738a550