### PR TITLE
Refactor axios import path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+!frontend/src/lib/
 parts/
 sdist/
 var/

--- a/frontend/src/api/axiosInstance.js
+++ b/frontend/src/api/axiosInstance.js
@@ -1,13 +1,13 @@
-import axiosInstance from './lib/axios';
+import axios from '../lib/axios';
 
 // تنظیمات پایه axios
-const axiosInstance = axiosInstance.create({
+const api = axios.create({
   baseURL: process.env.REACT_APP_API_URL || 'http://localhost:8000',
   timeout: 10000,
 });
 
 // Interceptor برای افزودن خودکار Authorization header
-axiosInstance.interceptors.request.use(
+api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('access_token');
     if (token) {
@@ -21,7 +21,7 @@ axiosInstance.interceptors.request.use(
 );
 
 // Interceptor برای مدیریت خطاهای احراز هویت
-axiosInstance.interceptors.response.use(
+api.interceptors.response.use(
   (response) => {
     return response;
   },
@@ -35,14 +35,14 @@ axiosInstance.interceptors.response.use(
       try {
         const refreshToken = localStorage.getItem('refresh_token');
         if (refreshToken) {
-          const response = await axiosInstance.post('/api/auth/token/refresh/', {
+          const response = await api.post('/api/auth/token/refresh/', {
             refresh: refreshToken,
           });
           
           localStorage.setItem('access_token', response.data.access);
           originalRequest.headers.Authorization = `Bearer ${response.data.access}`;
           
-          return axiosInstance(originalRequest);
+          return api(originalRequest);
         }
       } catch (refreshError) {
         // اگر refresh token هم معتبر نباشد، کاربر را به صفحه لاگین هدایت کن
@@ -57,4 +57,4 @@ axiosInstance.interceptors.response.use(
   }
 );
 
-export default axiosInstance; 
+export default api;

--- a/frontend/src/components/AuthWidget.jsx
+++ b/frontend/src/components/AuthWidget.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 

--- a/frontend/src/components/AuthWidget.test.js
+++ b/frontend/src/components/AuthWidget.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AuthWidget from './AuthWidget';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 
 // Mock مورد نیاز

--- a/frontend/src/components/BusinessWidget.js
+++ b/frontend/src/components/BusinessWidget.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';

--- a/frontend/src/components/CombinedDashboardComponent.js
+++ b/frontend/src/components/CombinedDashboardComponent.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 
 // کامپوننت‌های داشبورد

--- a/frontend/src/components/NotificationWidget.js
+++ b/frontend/src/components/NotificationWidget.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/frontend/src/components/OrderWidget.jsx
+++ b/frontend/src/components/OrderWidget.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import Slider from 'react-slick';

--- a/frontend/src/components/PaymentButton.jsx
+++ b/frontend/src/components/PaymentButton.jsx
@@ -24,7 +24,7 @@ import {
   Badge,
 } from '@chakra-ui/react';
 import { FaCreditCard, FaExternalLinkAlt, FaCheckCircle } from 'react-icons/fa';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 
 const PaymentButton = ({ 
   orderId, 

--- a/frontend/src/components/PaymentWidget.jsx
+++ b/frontend/src/components/PaymentWidget.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, Badge, VStack, Heading, Divider, Spinner, Flex, Icon } from '@chakra-ui/react';
 import { FaMoneyCheckAlt, FaCheckCircle, FaTimesCircle, FaHourglassHalf, FaBan } from 'react-icons/fa';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { toast } from 'react-toastify';
 
 // تبدیل وضعیت پرداخت به رنگ و آیکون

--- a/frontend/src/components/SetDesignList.jsx
+++ b/frontend/src/components/SetDesignList.jsx
@@ -3,7 +3,7 @@ import {
   Paper, Typography, Table, TableBody, TableCell, TableContainer, 
   TableHead, TableRow, Button, Box, Chip, CircularProgress
 } from '@mui/material';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 
 const statusColors = {
   waiting: 'warning',

--- a/frontend/src/components/dashboard/BusinessDetailWidget.js
+++ b/frontend/src/components/dashboard/BusinessDetailWidget.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 

--- a/frontend/src/components/dashboard/BusinessDetailWidget.test.js
+++ b/frontend/src/components/dashboard/BusinessDetailWidget.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { BrowserRouter } from 'react-router-dom';
 import BusinessDetailWidget from './BusinessDetailWidget';
 import { toast } from 'react-toastify';

--- a/frontend/src/components/dashboard/DashboardGuide.js
+++ b/frontend/src/components/dashboard/DashboardGuide.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { FaLightbulb, FaArrowRight, FaTimes, FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 
 /**

--- a/frontend/src/components/dashboard/DashboardWidget.js
+++ b/frontend/src/components/dashboard/DashboardWidget.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 

--- a/frontend/src/components/dashboard/DashboardWidget.test.js
+++ b/frontend/src/components/dashboard/DashboardWidget.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import DashboardWidget from './DashboardWidget';
 import { toast } from 'react-toastify';
 

--- a/frontend/src/components/dashboard/NotificationWidget.js
+++ b/frontend/src/components/dashboard/NotificationWidget.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { motion } from 'framer-motion';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';

--- a/frontend/src/components/dashboard/NotificationWidget.test.js
+++ b/frontend/src/components/dashboard/NotificationWidget.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import NotificationWidget from './NotificationWidget';
 

--- a/frontend/src/components/dashboard/ReportWidget.js
+++ b/frontend/src/components/dashboard/ReportWidget.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { motion } from 'framer-motion';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';

--- a/frontend/src/components/dashboard/ReportWidget.test.js
+++ b/frontend/src/components/dashboard/ReportWidget.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import ReportWidget from './ReportWidget';
 

--- a/frontend/src/components/dashboard/SalesDetailWidget.js
+++ b/frontend/src/components/dashboard/SalesDetailWidget.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend } from 'chart.js';

--- a/frontend/src/components/dashboard/SalesDetailWidget.test.js
+++ b/frontend/src/components/dashboard/SalesDetailWidget.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import SalesDetailWidget from './SalesDetailWidget';
 

--- a/frontend/src/components/designs/DesignWidget.jsx
+++ b/frontend/src/components/designs/DesignWidget.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import Slider from "react-slick";
 import { motion } from 'framer-motion';

--- a/frontend/src/components/main/InteractiveGuide.js
+++ b/frontend/src/components/main/InteractiveGuide.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 
 /**
  * کامپوننت راهنمای تعاملی برای کاربران کم‌تجربه

--- a/frontend/src/components/main/InteractiveGuide.test.js
+++ b/frontend/src/components/main/InteractiveGuide.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import InteractiveGuide from './InteractiveGuide';
 
 // ماک کردن ماژول axios

--- a/frontend/src/lib/axios.js
+++ b/frontend/src/lib/axios.js
@@ -1,0 +1,3 @@
+import axios from 'axios';
+
+export default axios;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../lib/axios';
 import { useNavigate } from 'react-router-dom';
 
 const Home = () => {

--- a/frontend/src/pages/auth/UserForm.jsx
+++ b/frontend/src/pages/auth/UserForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/businesses/CreateBusiness.js
+++ b/frontend/src/pages/businesses/CreateBusiness.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/businesses/DetailBusiness.js
+++ b/frontend/src/pages/businesses/DetailBusiness.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/businesses/EditBusiness.js
+++ b/frontend/src/pages/businesses/EditBusiness.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/businesses/ListBusinesses.js
+++ b/frontend/src/pages/businesses/ListBusinesses.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/communication/ChatPage.js
+++ b/frontend/src/pages/communication/ChatPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/communication/CreateChat.js
+++ b/frontend/src/pages/communication/CreateChat.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/communication/ListChats.js
+++ b/frontend/src/pages/communication/ListChats.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/communication/ListNotifications.js
+++ b/frontend/src/pages/communication/ListNotifications.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/core/SystemSettings.jsx
+++ b/frontend/src/pages/core/SystemSettings.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 
 const SystemSettings = ({ isAdmin }) => {

--- a/frontend/src/pages/core/SystemSettings.test.jsx
+++ b/frontend/src/pages/core/SystemSettings.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SystemSettings from './SystemSettings';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 
 // Mock کردن axios

--- a/frontend/src/pages/dashboard/DashboardPage.js
+++ b/frontend/src/pages/dashboard/DashboardPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 import { 

--- a/frontend/src/pages/dashboard/DashboardPage.test.js
+++ b/frontend/src/pages/dashboard/DashboardPage.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import DashboardPage from './DashboardPage';
 import { toast } from 'react-toastify';
 

--- a/frontend/src/pages/designs/BatchUpload.jsx
+++ b/frontend/src/pages/designs/BatchUpload.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/designs/DetailDesign.jsx
+++ b/frontend/src/pages/designs/DetailDesign.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/main/MainPage.js
+++ b/frontend/src/pages/main/MainPage.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { useNavigate } from 'react-router-dom';
 

--- a/frontend/src/pages/main/MainPage.test.js
+++ b/frontend/src/pages/main/MainPage.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import MainPage from './MainPage';
 

--- a/frontend/src/pages/notification/DetailNotification.js
+++ b/frontend/src/pages/notification/DetailNotification.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/orders/DetailOrder.jsx
+++ b/frontend/src/pages/orders/DetailOrder.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/orders/EditOrder.jsx
+++ b/frontend/src/pages/orders/EditOrder.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/orders/ListOrders.jsx
+++ b/frontend/src/pages/orders/ListOrders.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/reports/ReportDetail.js
+++ b/frontend/src/pages/reports/ReportDetail.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { motion } from 'framer-motion';
 import { 

--- a/frontend/src/pages/templates/DetailTemplate.jsx
+++ b/frontend/src/pages/templates/DetailTemplate.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/templates/EditUserTemplate.jsx
+++ b/frontend/src/pages/templates/EditUserTemplate.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/templates/ListTemplates.jsx
+++ b/frontend/src/pages/templates/ListTemplates.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/templates/UseTemplate.jsx
+++ b/frontend/src/pages/templates/UseTemplate.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/templates/UserTemplateDetail.jsx
+++ b/frontend/src/pages/templates/UserTemplateDetail.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { motion } from 'framer-motion';

--- a/frontend/src/pages/templates/UserTemplates.jsx
+++ b/frontend/src/pages/templates/UserTemplates.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axiosInstance from './lib/axios';
+import axiosInstance from '../../lib/axios';
 import { toast } from 'react-toastify';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';


### PR DESCRIPTION
## Summary
- add an axios re-export under `src/lib`
- use the new axios module in the API instance
- adjust all relative imports to reference the shared axios module
- unignore `frontend/src/lib/`

## Testing
- `python run_all_tests.py` *(fails: Couldn't import Django)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495b38ce28832a90bc08c14302b329