### PR TITLE
Fix OrderItem serializer field mismatch

### DIFF
--- a/backend/apps/orders/serializers.py
+++ b/backend/apps/orders/serializers.py
@@ -17,8 +17,12 @@ class OrderItemSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OrderItem
-        fields = ['id', 'order', 'design', 'design_id', 'user_template', 'user_template_id', 'quantity', 'price', 'created_at', 'updated_at']
-        read_only_fields = ['price']
+        fields = [
+            'id', 'order', 'design', 'design_id', 'user_template',
+            'user_template_id', 'quantity', 'unit_price',
+            'created_at', 'updated_at'
+        ]
+        read_only_fields = ['unit_price']
 
     def get_created_at(self, obj):
         return to_jalali(obj.created_at)

--- a/backend/apps/orders/tests.py
+++ b/backend/apps/orders/tests.py
@@ -60,14 +60,14 @@ class OrderModelTest(TestCase):
             order=order,
             design=design,
             quantity=2,
-            price=2000
+            unit_price=1000
         )
         
         OrderItem.objects.create(
             order=order,
             design=design,
             quantity=1,
-            price=1000
+            unit_price=1000
         )
         
         total = order.calculate_total_price()
@@ -108,7 +108,7 @@ class OrderAPITest(TestCase):
             order=self.order,
             design=self.design,
             quantity=2,
-            price=2000
+            unit_price=1000
         )
         
     def test_list_orders(self):


### PR DESCRIPTION
## Summary
- align OrderItemSerializer fields with the model
- update order tests to use `unit_price`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q djangorestframework-simplejwt`
- `pip install -q drf_spectacular`
- `pytest apps/orders/tests.py::OrderModelTest::test_calculate_total_price -q` *(fails: ModuleNotFoundError: No module named 'corsheaders')*

------
https://chatgpt.com/codex/tasks/task_e_684130892818832abb6f9170dd4b1fa9